### PR TITLE
Add OpenBSD support with pledge(2) and CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,18 +9,17 @@ on:
       - "**"
 
 jobs:
-  test:
-    name: ${{ matrix.os }} + ${{ matrix.compiler }}
-    runs-on: ${{ matrix.os }}
+  linux:
+    name: linux + ${{ matrix.compiler }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
         compiler: [gcc, clang]
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: make
       run: |
@@ -35,3 +34,51 @@ jobs:
         cd $HOME/src/github.com/user/clone
 
         CC=${{ matrix.compiler }} make test
+
+  macos:
+    name: macos + ${{ matrix.compiler }}
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [gcc, clang]
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: make
+      run: |
+        mkdir -p $HOME/src/github.com/user/clone
+        cp -R * $HOME/src/github.com/user/clone
+        cd $HOME/src/github.com/user/clone
+
+        CC=${{ matrix.compiler }} make
+
+    - name: make test
+      run: |
+        cd $HOME/src/github.com/user/clone
+
+        CC=${{ matrix.compiler }} make test
+
+  openbsd:
+    name: openbsd + clang
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Build and test on OpenBSD
+      uses: vmactions/openbsd-vm@v1
+      with:
+        usesh: true
+        prepare: |
+          pkg_add git
+        run: |
+          mkdir -p $HOME/src/github.com/user/clone
+          cp -R * $HOME/src/github.com/user/clone
+          cd $HOME/src/github.com/user/clone
+
+          make
+          make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
         CC=${{ matrix.compiler }} make test
 
   openbsd:
-    name: openbsd + clang
+    name: openbsd
     runs-on: ubuntu-latest
 
     steps:

--- a/clone.c
+++ b/clone.c
@@ -1,18 +1,6 @@
 #include "clone.h"
 #include "repository.h"
 
-#ifndef __dead
-#define __dead __attribute__((__noreturn__))
-#endif
-
-#ifndef nitems
-#define nitems(x) (sizeof((x)) / sizeof((x)[0]))
-#endif
-
-#ifndef __OpenBSD__
-#define pledge(promises, execpromises) (0)
-#endif
-
 extern char *__progname;
 
 static void __dead

--- a/clone.c
+++ b/clone.c
@@ -5,6 +5,10 @@
 #define __dead __attribute__((__noreturn__))
 #endif
 
+#ifndef nitems
+#define nitems(x) (sizeof((x)) / sizeof((x)[0]))
+#endif
+
 #ifndef __OpenBSD__
 #define pledge(promises, execpromises) (0)
 #endif
@@ -98,8 +102,7 @@ valid_git_ssh_pattern(const char *pattern)
 		"git@*:*/*",
 	};
 
-	for (size_t i = 0; i < sizeof(valid_patterns) /
-	    sizeof(valid_patterns[0]); i++) {
+	for (size_t i = 0; i < nitems(valid_patterns); i++) {
 		if (fnmatch(valid_patterns[i], pattern, 0) == 0)
 			return 1;
 	}
@@ -115,8 +118,7 @@ valid_git_https_pattern(const char *pattern)
 		"https://*/*/*",
 	};
 
-	for (size_t i = 0; i < sizeof(valid_patterns) /
-	    sizeof(valid_patterns[0]); i++) {
+	for (size_t i = 0; i < nitems(valid_patterns); i++) {
 		if (fnmatch(valid_patterns[i], pattern, 0) == 0)
 			return 1;
 	}
@@ -134,8 +136,7 @@ unsupported_git_clone_patterns(const char *pattern)
 		"ssh://git@*/*.git",
 	};
 
-	for (size_t i = 0; i < sizeof(invalid_patterns) /
-	    sizeof(invalid_patterns[0]); i++) {
+	for (size_t i = 0; i < nitems(invalid_patterns); i++) {
 		if (fnmatch(invalid_patterns[i], pattern, 0) == 0)
 			return 1;
 	}

--- a/clone.c
+++ b/clone.c
@@ -1,11 +1,17 @@
 #include "clone.h"
 #include "repository.h"
 
-static void
+#ifndef __dead
+#define __dead __attribute__((__noreturn__))
+#endif
+
+extern char *__progname;
+
+static void __dead
 usage(void)
 {
-	fprintf(stderr, "usage: clone [-n] pattern\n");
-	exit(2);
+	fprintf(stderr, "usage: %s [-n] pattern\n", __progname);
+	exit(1);
 }
 
 #ifndef CLONE_PATH

--- a/clone.c
+++ b/clone.c
@@ -5,6 +5,10 @@
 #define __dead __attribute__((__noreturn__))
 #endif
 
+#ifndef __OpenBSD__
+#define pledge(promises, execpromises) (0)
+#endif
+
 extern char *__progname;
 
 static void __dead
@@ -204,6 +208,9 @@ main(int argc, char *argv[])
 	char *clone_path, *location, *pattern, *url;
 	int nflag = 0;
 	int ch;
+
+	if (pledge("stdio rpath exec", NULL) == -1)
+		err(1, "pledge");
 
 	while ((ch = getopt(argc, argv, "n")) != -1) {
 		switch (ch) {

--- a/clone.h
+++ b/clone.h
@@ -12,6 +12,18 @@
 #include <string.h>
 #include <unistd.h>
 
+#ifndef __dead
+#define __dead __attribute__((__noreturn__))
+#endif
+
+#ifndef nitems
+#define nitems(x) (sizeof((x)) / sizeof((x)[0]))
+#endif
+
+#ifndef __OpenBSD__
+#define pledge(promises, execpromises) (0)
+#endif
+
 int	valid_git_ssh_pattern(const char *);
 int	valid_git_https_pattern(const char *);
 int	is_url_pattern(const char *);

--- a/clone.h
+++ b/clone.h
@@ -1,6 +1,8 @@
 #ifndef _CLONE_H_
 #define _CLONE_H_
 
+#include <sys/param.h>
+
 #include <err.h>
 #include <fnmatch.h>
 #include <limits.h>


### PR DESCRIPTION
Adopt OpenBSD conventions and add pledge(2) support with CI
coverage on an OpenBSD VM.

- Adopt OpenBSD style: __dead, __progname, exit code conventions
- Add pledge(2) to restrict process capabilities (no-op on non-OpenBSD)
- Use nitems() macro for array iteration with portable fallback
- Move portability shims (__dead, nitems, pledge) from clone.c to clone.h,
  following OpenBSD convention where projects with a shared header define
  these in the header (e.g. tmux.h, bgpd.h, smtpd.h, httpd.h)
- Split CI matrix into per-platform jobs and add OpenBSD via vmactions/openbsd-vm
- Update checkout action from v3 to v4