### PR TITLE
Add ssh:// URL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ git clone git@github.com:/user/repository /home/user/src/github.com/user/reposit
 or
 
 ```
+% clone -n ssh://anonymous@got.gameoftrees.org/got
+git clone ssh://anonymous@got.gameoftrees.org/got /home/user/src/got.gameoftrees.org/anonymous/got
+```
+
+or
+
+```
 % cd /home/user/src/github.com/user
 % clone -n another-repository
 git clone git@github.com:/user/another-repository /home/user/src/github.com/user/another-repository

--- a/clone.1
+++ b/clone.1
@@ -24,6 +24,10 @@ https://host/user/repository
 .It
 https://host/user/repository.git
 .It
+ssh://user@host/repository
+.It
+ssh://user@host/repository.git
+.It
 user/repository
 .It
 repository
@@ -58,6 +62,10 @@ To clone a repository from GitHub over ssh:
 To clone a repository from GitHub over https:
 .Pp
 .Dl % clone https://github.com/user/repository
+.Pp
+To clone a repository from a host that uses ssh:// URLs:
+.Pp
+.Dl % clone ssh://anonymous@got.gameoftrees.org/got
 .Pp
 To clone a repository from a custom git host:
 .Pp

--- a/clone.c
+++ b/clone.c
@@ -125,13 +125,28 @@ valid_git_https_pattern(const char *pattern)
 }
 
 int
+valid_git_ssh_url_pattern(const char *pattern)
+{
+	const char *valid_patterns[] = {
+		"ssh://*@*/*.git",
+		"ssh://*@*/*",
+	};
+
+	for (size_t i = 0; i < sizeof(valid_patterns) /
+	    sizeof(valid_patterns[0]); i++) {
+		if (fnmatch(valid_patterns[i], pattern, 0) == 0)
+			return 1;
+	}
+
+	return 0;
+}
+
+int
 unsupported_git_clone_patterns(const char *pattern)
 {
 	const char *invalid_patterns[] = {
 		"git://*/*",
 		"git://*/*.git",
-		"ssh://git@*/*",
-		"ssh://git@*/*.git",
 	};
 
 	for (size_t i = 0; i < sizeof(invalid_patterns) /
@@ -148,6 +163,7 @@ is_url_pattern(const char *pattern)
 {
 	return valid_git_ssh_pattern(pattern) ||
 	    valid_git_https_pattern(pattern) ||
+	    valid_git_ssh_url_pattern(pattern) ||
 	    unsupported_git_clone_patterns(pattern);
 }
 

--- a/clone.h
+++ b/clone.h
@@ -12,6 +12,7 @@
 
 int	valid_git_ssh_pattern(const char *);
 int	valid_git_https_pattern(const char *);
+int	valid_git_ssh_url_pattern(const char *);
 int	is_url_pattern(const char *);
 
 #endif /* _CLONE_H_ */

--- a/repository.c
+++ b/repository.c
@@ -97,6 +97,41 @@ extract_repository_from_https_pattern(struct Repository *repository,
 }
 
 void
+extract_repository_from_ssh_url_pattern(struct Repository *repository,
+    const char *pattern)
+{
+	const char *at, *host_end, *host_start, *name_end, *name_start, *proto;
+
+	repository->protocol = SSH_URL;
+
+	proto = strstr(pattern, "://");
+	if (proto == NULL)
+		return;
+
+	at = strchr(proto + 3, '@');
+	if (at == NULL)
+		return;
+	/* user is the login name from the URL; it doubles as the directory
+	 * component between host and name in $CLONE_PATH/host/user/name. */
+	repository->user = copy_substring(proto + 3, at);
+
+	host_start = at + 1;
+	host_end = strchr(host_start, '/');
+	if (host_end == NULL) {
+		free(repository->user);
+		repository->user = NULL;
+		return;
+	}
+	repository->host = copy_substring(host_start, host_end);
+
+	name_start = host_end + 1;
+	name_end = find_git_suffix(name_start);
+	if (name_end == NULL)
+		name_end = pattern + strlen(pattern);
+	repository->name = copy_substring(name_start, name_end);
+}
+
+void
 overload_repository_with_pattern(struct Repository *repository,
     const char *pattern)
 {
@@ -148,6 +183,8 @@ extract_repository_from_pattern(const char *pattern)
 		extract_repository_from_ssh_pattern(&repository, pattern);
 	else if (valid_git_https_pattern(pattern))
 		extract_repository_from_https_pattern(&repository, pattern);
+	else if (valid_git_ssh_url_pattern(pattern))
+		extract_repository_from_ssh_url_pattern(&repository, pattern);
 
 	return repository;
 }
@@ -281,12 +318,37 @@ extract_https_url_from_repository(struct Repository repository)
 }
 
 char *
+extract_ssh_url_string_from_repository(struct Repository repository)
+{
+	char *out;
+	int len;
+	size_t size;
+
+	len = snprintf(NULL, 0, "ssh://%s@%s/%s", repository.user,
+	    repository.host, repository.name);
+	if (len < 0 || (size_t)len > SIZE_MAX - 1)
+		return NULL;
+
+	size = (size_t)len + 1;
+	out = malloc(size);
+	if (out == NULL)
+		return NULL;
+
+	snprintf(out, size, "ssh://%s@%s/%s", repository.user,
+	    repository.host, repository.name);
+
+	return out;
+}
+
+char *
 extract_url_from_repository(struct Repository repository)
 {
 	if (repository.protocol == SSH)
 		return extract_ssh_url_from_repository(repository);
 	else if (repository.protocol == HTTPS)
 		return extract_https_url_from_repository(repository);
+	else if (repository.protocol == SSH_URL)
+		return extract_ssh_url_string_from_repository(repository);
 	else
 		return NULL;
 }

--- a/repository.h
+++ b/repository.h
@@ -12,6 +12,7 @@ enum Protocol {
 	UNDEFINED,
 	SSH,
 	HTTPS,
+	SSH_URL,
 };
 
 struct Repository {

--- a/tests/clone-inside-project-base-directory.sh
+++ b/tests/clone-inside-project-base-directory.sh
@@ -18,6 +18,15 @@ if testcase "clone full git+ssh git.sr.ht URLs inside clone's directory structur
     "$(clone "git@git.sr.ht:~user/project.git")"
 fi
 
+if testcase "clone full ssh:// URLs inside clone's directory structure"; then
+  assert_eq \
+    "git clone ssh://anonymous@got.gameoftrees.org/got $HOME/src/got.gameoftrees.org/anonymous/got" \
+    "$(clone "ssh://anonymous@got.gameoftrees.org/got.git")"
+  assert_eq \
+    "git clone ssh://anonymous@got.gameoftrees.org/got $HOME/src/got.gameoftrees.org/anonymous/got" \
+    "$(clone "ssh://anonymous@got.gameoftrees.org/got")"
+fi
+
 if testcase "clone full https github.com URLs inside clone's directory structure"; then
   assert_eq \
     "git clone https://github.com/user/project $HOME/src/github.com/user/project" \
@@ -25,6 +34,27 @@ if testcase "clone full https github.com URLs inside clone's directory structure
   assert_eq \
     "git clone https://github.com/user/project $HOME/src/github.com/user/project" \
     "$(clone "https://github.com/user/project.git")"
+fi
+
+# Shorthand patterns always reconstruct with git@ regardless of how the host
+# directory was created. There is no protocol stored in the directory tree.
+if testcase "clone shorthand patterns inside ssh:// host directory structure use git@ protocol"; then
+  prior=$(pwd)
+  tmpdir=$(mktemp -d "$HOME/src/test.XXXXXX") || exit 1
+  host=$(basename "$tmpdir")
+  sshdir="$tmpdir/anonymous"
+  mkdir "$sshdir" || exit 1
+  cd "$sshdir" || exit 1
+
+  assert_eq \
+    "git clone git@$host:anonymous/another-repo $HOME/src/$host/anonymous/another-repo" \
+    "$(clone "another-repo")"
+  assert_eq \
+    "git clone git@$host:user/another-repo $HOME/src/$host/user/another-repo" \
+    "$(clone "user/another-repo")"
+
+  cd "$prior" || exit 1
+  rm -rf "$tmpdir"
 fi
 
 if testcase "clone user/repository_name patterns inside clone's directory structure"; then

--- a/tests/clone-outside-project-base-directory.sh
+++ b/tests/clone-outside-project-base-directory.sh
@@ -37,4 +37,13 @@ if testcase "clone full https:// any other URLs outside clone's directory struct
     "$(clone "https://example.com/user/project.git")"
 fi
 
+if testcase "clone full ssh:// URLs outside clone's directory structure"; then
+  assert_eq \
+    "git clone ssh://anonymous@got.gameoftrees.org/got $HOME/src/got.gameoftrees.org/anonymous/got" \
+    "$(clone "ssh://anonymous@got.gameoftrees.org/got.git")"
+  assert_eq \
+    "git clone ssh://anonymous@got.gameoftrees.org/got $HOME/src/got.gameoftrees.org/anonymous/got" \
+    "$(clone "ssh://anonymous@got.gameoftrees.org/got")"
+fi
+
 rmdir "$tmpdir"

--- a/tests/clone-rejects-bad-patterns.sh
+++ b/tests/clone-rejects-bad-patterns.sh
@@ -7,15 +7,6 @@ if testcase "clone rejects bad patterns - git://"; then
     "$(clone "git://github.com/user/project.git")"
 fi
 
-if testcase "clone rejects bad patterns - ssh://"; then
-  assert_eq \
-    "clone: could not extract repository: ssh://git@github.com:user/project" \
-    "$(clone "ssh://git@github.com:user/project")"
-  assert_eq \
-    "clone: could not extract repository: ssh://git@github.com:user/project.git" \
-    "$(clone "ssh://git@github.com:user/project.git")"
-fi
-
 if testcase "clone rejects path traversal in hostname"; then
   assert_eq \
     "clone: could not extract repository: git@../../etc:user/repo" \
@@ -23,6 +14,9 @@ if testcase "clone rejects path traversal in hostname"; then
   assert_eq \
     "clone: could not extract repository: git@foo/../bar:user/repo" \
     "$(clone "git@foo/../bar:user/repo")"
+  assert_eq \
+    "clone: could not extract repository: ssh://anonymous@../../etc/repo" \
+    "$(clone "ssh://anonymous@../../etc/repo")"
 fi
 
 if testcase "clone rejects path traversal in user"; then
@@ -32,6 +26,9 @@ if testcase "clone rejects path traversal in user"; then
   assert_eq \
     "clone: could not extract repository: https://github.com/../user/repo" \
     "$(clone "https://github.com/../user/repo")"
+  assert_eq \
+    "clone: could not extract repository: ssh://..@got.gameoftrees.org/got" \
+    "$(clone "ssh://..@got.gameoftrees.org/got")"
 fi
 
 if testcase "clone rejects path traversal in repository name"; then
@@ -41,4 +38,13 @@ if testcase "clone rejects path traversal in repository name"; then
   assert_eq \
     "clone: could not extract repository: git@github.com:user/repo/../other" \
     "$(clone "git@github.com:user/repo/../other")"
+  assert_eq \
+    "clone: could not extract repository: ssh://anonymous@got.gameoftrees.org/../got" \
+    "$(clone "ssh://anonymous@got.gameoftrees.org/../got")"
+fi
+
+if testcase "clone rejects bad patterns - ssh:// deep path"; then
+  assert_eq \
+    "clone: could not extract repository: ssh://anonymous@got.gameoftrees.org/a/b/got" \
+    "$(clone "ssh://anonymous@got.gameoftrees.org/a/b/got")"
 fi


### PR DESCRIPTION
Some hosts only advertise ssh:// URLs with no separate user/repo path
structure, e.g. `ssh://anonymous@got.gameoftrees.org/got.git`. The
`git@` shorthand cannot represent these.

`ssh://user@host/name` is parsed with the login name mapped to the user
directory component, placing the clone at `$CLONE_PATH/host/user/name`.
The URL is passed to `git-clone(1)` as-is (without `.git` suffix).

Shorthand patterns from inside the clone directory tree still reconstruct
with `git@` -- there is no protocol stored in the directory structure.

The man page and README are updated with the new pattern and an example.