### PR TITLE
Support all GIT URL types from git-pull(1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ PROG=	clone
 
 SRCS=	clone.c
 SRCS+=	repository.c
+SRCS+=	url.c
 
 OBJS=		${SRCS:.c=.o}
 

--- a/clone.1
+++ b/clone.1
@@ -16,13 +16,11 @@ current directory structure to determine the clone path for a repository.
 The program accepts the following patterns for the repository:
 .Bl -dash
 .It
-git@host:user/repository
+[user@]host:user/repository[.git]
 .It
-git@host:user/repository.git
+ssh://[user@]host[:port]/repository[.git]
 .It
-https://host/user/repository
-.It
-https://host/user/repository.git
+https://host[:port]/user/repository[.git]
 .It
 user/repository
 .It
@@ -31,6 +29,16 @@ repository
 .Pp
 The two latter are only available if the program is run inside the known
 directory structure.
+.Pp
+The following protocols are not supported:
+.Bl -dash
+.It
+git:// \(en insecure, no authentication
+.It
+http:// \(en insecure, use https:// instead
+.It
+ftp[s]:// \(en deprecated
+.El
 .Sh DIRECTORY STRUCTURE
 The default directory pattern for the cloned repositories is:
 .Pp
@@ -58,6 +66,10 @@ To clone a repository from GitHub over ssh:
 To clone a repository from GitHub over https:
 .Pp
 .Dl % clone https://github.com/user/repository
+.Pp
+To clone a repository using an ssh:// URL:
+.Pp
+.Dl % clone ssh://anonymous@got.gameoftrees.org/got
 .Pp
 To clone a repository from a custom git host:
 .Pp

--- a/clone.c
+++ b/clone.c
@@ -137,7 +137,7 @@ invalid_repository(struct Repository repository)
 int
 main(int argc, char *argv[])
 {
-	struct Repository repository = { NULL, NULL, NULL, NULL, SCHEME_UNDEFINED };
+	struct Repository repository = { NULL, NULL, NULL, NULL, NULL, SCHEME_UNDEFINED };
 	struct url parsed = {0};
 	char *cmd[] = { "git", "clone", NULL, NULL, NULL };
 	char *clone_path, *clone_url, *location, *pattern;

--- a/clone.c
+++ b/clone.c
@@ -113,6 +113,8 @@ contains_path_traversal(const char *str)
 		return 1;
 	if (strchr(str, '/') != NULL)
 		return 1;
+	if (strchr(str, ':') != NULL)
+		return 1;
 	return 0;
 }
 
@@ -165,8 +167,7 @@ main(int argc, char *argv[])
 	pattern = argv[0];
 
 	if (parse_url(pattern, &parsed) == 0) {
-		if (parsed.scheme == SCHEME_GIT ||
-		    parsed.scheme == SCHEME_SSH) {
+		if (parsed.scheme == SCHEME_GIT) {
 			free_url(&parsed);
 			errx(1, "could not extract repository: %s",
 			    pattern);

--- a/clone.c
+++ b/clone.c
@@ -174,7 +174,7 @@ main(int argc, char *argv[])
 		    parsed.scheme == SCHEME_HTTP ||
 		    parsed.scheme == SCHEME_FTP) {
 			free_url(&parsed);
-			errx(1, "could not extract repository: %s",
+			errx(1, "unsupported protocol: %s",
 			    pattern);
 		}
 		repository = extract_repository_from_url(&parsed);

--- a/clone.c
+++ b/clone.c
@@ -1,5 +1,6 @@
 #include "clone.h"
 #include "repository.h"
+#include "url.h"
 
 extern char *__progname;
 
@@ -83,64 +84,6 @@ get_clone_path(void)
 }
 
 int
-valid_git_ssh_pattern(const char *pattern)
-{
-	const char *valid_patterns[] = {
-		"git@*:*/*.git",
-		"git@*:*/*",
-	};
-
-	for (size_t i = 0; i < nitems(valid_patterns); i++) {
-		if (fnmatch(valid_patterns[i], pattern, 0) == 0)
-			return 1;
-	}
-
-	return 0;
-}
-
-int
-valid_git_https_pattern(const char *pattern)
-{
-	const char *valid_patterns[] = {
-		"https://*/*/*.git",
-		"https://*/*/*",
-	};
-
-	for (size_t i = 0; i < nitems(valid_patterns); i++) {
-		if (fnmatch(valid_patterns[i], pattern, 0) == 0)
-			return 1;
-	}
-
-	return 0;
-}
-
-int
-unsupported_git_clone_patterns(const char *pattern)
-{
-	const char *invalid_patterns[] = {
-		"git://*/*",
-		"git://*/*.git",
-		"ssh://git@*/*",
-		"ssh://git@*/*.git",
-	};
-
-	for (size_t i = 0; i < nitems(invalid_patterns); i++) {
-		if (fnmatch(invalid_patterns[i], pattern, 0) == 0)
-			return 1;
-	}
-
-	return 0;
-}
-
-int
-is_url_pattern(const char *pattern)
-{
-	return valid_git_ssh_pattern(pattern) ||
-	    valid_git_https_pattern(pattern) ||
-	    unsupported_git_clone_patterns(pattern);
-}
-
-int
 cwd_is_inside_clone_path(const char *clone_path)
 {
 	char cwd[PATH_MAX];
@@ -177,7 +120,7 @@ int
 invalid_repository(struct Repository repository)
 {
 	if (repository.host == NULL || repository.user == NULL ||
-	    repository.name == NULL || repository.protocol == UNDEFINED)
+	    repository.name == NULL || repository.scheme == SCHEME_UNDEFINED)
 		return 1;
 	if (repository.host[0] == '\0' || repository.user[0] == '\0' ||
 	    repository.name[0] == '\0')
@@ -192,9 +135,10 @@ invalid_repository(struct Repository repository)
 int
 main(int argc, char *argv[])
 {
-	struct Repository repository = { NULL, NULL, NULL, UNDEFINED };
+	struct Repository repository = { NULL, NULL, NULL, SCHEME_UNDEFINED };
+	struct url parsed = {0};
 	char *cmd[] = { "git", "clone", NULL, NULL, NULL };
-	char *clone_path, *location, *pattern, *url;
+	char *clone_path, *clone_url, *location, *pattern;
 	int nflag = 0;
 	int ch;
 
@@ -220,10 +164,18 @@ main(int argc, char *argv[])
 
 	pattern = argv[0];
 
-	if (is_url_pattern(pattern))
-		repository = extract_repository_from_pattern(pattern);
-	else if (cwd_is_inside_clone_path(clone_path))
+	if (parse_url(pattern, &parsed) == 0) {
+		if (parsed.scheme == SCHEME_GIT ||
+		    parsed.scheme == SCHEME_SSH) {
+			free_url(&parsed);
+			errx(1, "could not extract repository: %s",
+			    pattern);
+		}
+		repository = extract_repository_from_url(&parsed);
+		free_url(&parsed);
+	} else if (cwd_is_inside_clone_path(clone_path)) {
 		repository = extract_repository_from_cwd(clone_path, pattern);
+	}
 
 	if (invalid_repository(repository)) {
 		free(clone_path);
@@ -232,26 +184,26 @@ main(int argc, char *argv[])
 	}
 
 	location = extract_location_from_repository(clone_path, repository);
-	url = extract_url_from_repository(repository);
+	clone_url = extract_url_from_repository(repository);
 
-	if (location == NULL || url == NULL) {
+	if (location == NULL || clone_url == NULL) {
 		free(clone_path);
 		free(location);
-		free(url);
+		free(clone_url);
 		free_repository(&repository);
 		err(1, NULL);
 	}
 
 	if (nflag) {
-		fprintf(stdout, "%s %s %s\n", "git clone", url, location);
+		fprintf(stdout, "%s %s %s\n", "git clone", clone_url, location);
 		free(clone_path);
 		free(location);
-		free(url);
+		free(clone_url);
 		free_repository(&repository);
 		return 0;
 	}
 
-	cmd[2] = url;
+	cmd[2] = clone_url;
 	cmd[3] = location;
 	execvp(cmd[0], cmd);
 	err(1, "git");

--- a/clone.c
+++ b/clone.c
@@ -167,7 +167,9 @@ main(int argc, char *argv[])
 	pattern = argv[0];
 
 	if (parse_url(pattern, &parsed) == 0) {
-		if (parsed.scheme == SCHEME_GIT) {
+		if (parsed.scheme == SCHEME_GIT ||
+		    parsed.scheme == SCHEME_HTTP ||
+		    parsed.scheme == SCHEME_FTP) {
 			free_url(&parsed);
 			errx(1, "could not extract repository: %s",
 			    pattern);

--- a/clone.c
+++ b/clone.c
@@ -137,7 +137,7 @@ invalid_repository(struct Repository repository)
 int
 main(int argc, char *argv[])
 {
-	struct Repository repository = { NULL, NULL, NULL, SCHEME_UNDEFINED };
+	struct Repository repository = { NULL, NULL, NULL, NULL, SCHEME_UNDEFINED };
 	struct url parsed = {0};
 	char *cmd[] = { "git", "clone", NULL, NULL, NULL };
 	char *clone_path, *clone_url, *location, *pattern;

--- a/clone.c
+++ b/clone.c
@@ -140,7 +140,7 @@ invalid_repository(struct Repository repository)
 int
 main(int argc, char *argv[])
 {
-	struct Repository repository = { NULL, NULL, NULL, NULL, NULL, SCHEME_UNDEFINED };
+	struct Repository repository = {0};
 	struct url parsed = {0};
 	char *cmd[] = { "git", "clone", NULL, NULL, NULL };
 	char *clone_path, *clone_url, *location, *pattern;

--- a/clone.c
+++ b/clone.c
@@ -131,6 +131,9 @@ invalid_repository(struct Repository repository)
 	    contains_path_traversal(repository.user) ||
 	    contains_path_traversal(repository.name))
 		return 1;
+	if (repository.port != NULL &&
+	    contains_path_traversal(repository.port))
+		return 1;
 	return 0;
 }
 

--- a/clone.h
+++ b/clone.h
@@ -1,5 +1,5 @@
-#ifndef _CLONE_H_
-#define _CLONE_H_
+#ifndef _CLONE_CLONE_H_
+#define _CLONE_CLONE_H_
 
 #include <sys/param.h>
 
@@ -24,8 +24,4 @@
 #define pledge(promises, execpromises) (0)
 #endif
 
-int	valid_git_ssh_pattern(const char *);
-int	valid_git_https_pattern(const char *);
-int	is_url_pattern(const char *);
-
-#endif /* _CLONE_H_ */
+#endif /* _CLONE_CLONE_H_ */

--- a/repository.c
+++ b/repository.c
@@ -39,7 +39,7 @@ copy_substring(const char *start, const char *end)
 struct Repository
 extract_repository_from_url(const struct url *url)
 {
-	struct Repository repository = {NULL, NULL, NULL, SCHEME_UNDEFINED};
+	struct Repository repository = {NULL, NULL, NULL, NULL, SCHEME_UNDEFINED};
 	const char *name_start, *slash, *suffix;
 
 	if (url == NULL)
@@ -77,6 +77,13 @@ extract_repository_from_url(const struct url *url)
 		if (repository.name == NULL)
 			err(1, NULL);
 		return repository;
+	}
+
+	/* SCP: preserve SSH login user for URL reconstruction */
+	if (url->scheme == SCHEME_SCP && url->user != NULL) {
+		repository.login_user = strdup(url->user);
+		if (repository.login_user == NULL)
+			err(1, NULL);
 	}
 
 	/* SCP and HTTPS: path is user/repo */
@@ -143,7 +150,7 @@ overload_repository_with_pattern(struct Repository *repository,
 struct Repository
 extract_repository_from_cwd(const char *clone_path, const char *pattern)
 {
-	struct Repository repository = {NULL, NULL, NULL, SCHEME_SCP};
+	struct Repository repository = {NULL, NULL, NULL, NULL, SCHEME_SCP};
 	char cwd[PATH_MAX];
 	char *end, *start;
 	const char *suffix;
@@ -226,10 +233,13 @@ char *
 extract_ssh_url_from_repository(struct Repository repository)
 {
 	char *out;
+	const char *login;
 	int len;
 	size_t size;
 
-	len = snprintf(NULL, 0, "git@%s:%s/%s", repository.host,
+	login = repository.login_user != NULL ? repository.login_user : "git";
+
+	len = snprintf(NULL, 0, "%s@%s:%s/%s", login, repository.host,
 	    repository.user, repository.name);
 	if (len < 0 || (size_t)len > SIZE_MAX - 1)
 		return NULL;
@@ -239,7 +249,7 @@ extract_ssh_url_from_repository(struct Repository repository)
 	if (out == NULL)
 		return NULL;
 
-	snprintf(out, size, "git@%s:%s/%s", repository.host,
+	snprintf(out, size, "%s@%s:%s/%s", login, repository.host,
 	    repository.user, repository.name);
 
 	return out;
@@ -310,8 +320,10 @@ free_repository(struct Repository *repository)
 	free(repository->host);
 	free(repository->user);
 	free(repository->name);
+	free(repository->login_user);
 	repository->host = NULL;
 	repository->user = NULL;
 	repository->name = NULL;
+	repository->login_user = NULL;
 	repository->scheme = SCHEME_UNDEFINED;
 }

--- a/repository.c
+++ b/repository.c
@@ -39,7 +39,7 @@ copy_substring(const char *start, const char *end)
 struct Repository
 extract_repository_from_url(const struct url *url)
 {
-	struct Repository repository = {NULL, NULL, NULL, NULL, SCHEME_UNDEFINED};
+	struct Repository repository = {NULL, NULL, NULL, NULL, NULL, SCHEME_UNDEFINED};
 	const char *name_start, *slash, *suffix;
 
 	if (url == NULL)
@@ -54,6 +54,12 @@ extract_repository_from_url(const struct url *url)
 	if (url->host != NULL) {
 		repository.host = strdup(url->host);
 		if (repository.host == NULL)
+			err(1, NULL);
+	}
+
+	if (url->port != NULL) {
+		repository.port = strdup(url->port);
+		if (repository.port == NULL)
 			err(1, NULL);
 	}
 
@@ -150,7 +156,7 @@ overload_repository_with_pattern(struct Repository *repository,
 struct Repository
 extract_repository_from_cwd(const char *clone_path, const char *pattern)
 {
-	struct Repository repository = {NULL, NULL, NULL, NULL, SCHEME_SCP};
+	struct Repository repository = {NULL, NULL, NULL, NULL, NULL, SCHEME_SCP};
 	char cwd[PATH_MAX];
 	char *end, *start;
 	const char *suffix;
@@ -262,8 +268,14 @@ extract_https_url_from_repository(struct Repository repository)
 	int len;
 	size_t size;
 
-	len = snprintf(NULL, 0, "https://%s/%s/%s", repository.host,
-	    repository.user, repository.name);
+	if (repository.port != NULL) {
+		len = snprintf(NULL, 0, "https://%s:%s/%s/%s",
+		    repository.host, repository.port, repository.user,
+		    repository.name);
+	} else {
+		len = snprintf(NULL, 0, "https://%s/%s/%s",
+		    repository.host, repository.user, repository.name);
+	}
 	if (len < 0 || (size_t)len > SIZE_MAX - 1)
 		return NULL;
 
@@ -272,8 +284,14 @@ extract_https_url_from_repository(struct Repository repository)
 	if (out == NULL)
 		return NULL;
 
-	snprintf(out, size, "https://%s/%s/%s", repository.host,
-	    repository.user, repository.name);
+	if (repository.port != NULL) {
+		snprintf(out, size, "https://%s:%s/%s/%s",
+		    repository.host, repository.port, repository.user,
+		    repository.name);
+	} else {
+		snprintf(out, size, "https://%s/%s/%s", repository.host,
+		    repository.user, repository.name);
+	}
 
 	return out;
 }
@@ -285,8 +303,14 @@ extract_ssh_url_string_from_repository(struct Repository repository)
 	int len;
 	size_t size;
 
-	len = snprintf(NULL, 0, "ssh://%s@%s/%s", repository.user,
-	    repository.host, repository.name);
+	if (repository.port != NULL) {
+		len = snprintf(NULL, 0, "ssh://%s@%s:%s/%s",
+		    repository.user, repository.host, repository.port,
+		    repository.name);
+	} else {
+		len = snprintf(NULL, 0, "ssh://%s@%s/%s",
+		    repository.user, repository.host, repository.name);
+	}
 	if (len < 0 || (size_t)len > SIZE_MAX - 1)
 		return NULL;
 
@@ -295,8 +319,14 @@ extract_ssh_url_string_from_repository(struct Repository repository)
 	if (out == NULL)
 		return NULL;
 
-	snprintf(out, size, "ssh://%s@%s/%s", repository.user,
-	    repository.host, repository.name);
+	if (repository.port != NULL) {
+		snprintf(out, size, "ssh://%s@%s:%s/%s",
+		    repository.user, repository.host, repository.port,
+		    repository.name);
+	} else {
+		snprintf(out, size, "ssh://%s@%s/%s", repository.user,
+		    repository.host, repository.name);
+	}
 
 	return out;
 }
@@ -321,9 +351,11 @@ free_repository(struct Repository *repository)
 	free(repository->user);
 	free(repository->name);
 	free(repository->login_user);
+	free(repository->port);
 	repository->host = NULL;
 	repository->user = NULL;
 	repository->name = NULL;
 	repository->login_user = NULL;
+	repository->port = NULL;
 	repository->scheme = SCHEME_UNDEFINED;
 }

--- a/repository.c
+++ b/repository.c
@@ -39,7 +39,7 @@ copy_substring(const char *start, const char *end)
 struct Repository
 extract_repository_from_url(const struct url *url)
 {
-	struct Repository repository = {NULL, NULL, NULL, NULL, NULL, SCHEME_UNDEFINED};
+	struct Repository repository = {0};
 	const char *name_start, *slash, *suffix;
 
 	if (url == NULL)
@@ -156,7 +156,7 @@ overload_repository_with_pattern(struct Repository *repository,
 struct Repository
 extract_repository_from_cwd(const char *clone_path, const char *pattern)
 {
-	struct Repository repository = {NULL, NULL, NULL, NULL, NULL, SCHEME_SCP};
+	struct Repository repository = {.scheme = SCHEME_SCP};
 	char cwd[PATH_MAX];
 	char *end, *start;
 	const char *suffix;

--- a/repository.c
+++ b/repository.c
@@ -36,64 +36,47 @@ copy_substring(const char *start, const char *end)
 	return result;
 }
 
-void
-extract_repository_from_ssh_pattern(struct Repository *repository,
-    const char *pattern)
+struct Repository
+extract_repository_from_url(const struct url *url)
 {
-	const char *at, *colon, *end, *slash;
+	struct Repository repository = {NULL, NULL, NULL, SCHEME_UNDEFINED};
+	const char *name_start, *slash, *suffix;
 
-	repository->protocol = SSH;
+	if (url == NULL)
+		return repository;
 
-	at = strchr(pattern, '@');
-	colon = strchr(pattern, ':');
-	slash = strchr(pattern, '/');
+	if (url->scheme != SCHEME_SCP && url->scheme != SCHEME_HTTPS)
+		return repository;
 
-	if (at != NULL && colon != NULL && at < colon)
-		repository->host = copy_substring(at + 1, colon);
+	repository.scheme = url->scheme;
 
-	if (colon != NULL && slash != NULL && colon < slash)
-		repository->user = copy_substring(colon + 1, slash);
-
-	if (slash != NULL) {
-		end = find_git_suffix(slash);
-		if (end == NULL)
-			end = pattern + strlen(pattern);
-		repository->name = copy_substring(slash + 1, end);
+	if (url->host != NULL) {
+		repository.host = strdup(url->host);
+		if (repository.host == NULL)
+			err(1, NULL);
 	}
-}
 
-void
-extract_repository_from_https_pattern(struct Repository *repository,
-    const char *pattern)
-{
-	const char *host_end, *host_start, *name_end, *name_start, *proto,
-		   *user_end, *user_start;
+	if (url->path == NULL)
+		return repository;
 
-	repository->protocol = HTTPS;
+	slash = strchr(url->path, '/');
+	if (slash == NULL)
+		return repository;
 
-	proto = strstr(pattern, "://");
-	if (proto == NULL)
-		return;
-	host_start = proto + 3;
-	host_end = strchr(host_start, '/');
-	if (host_end == NULL)
-		return;
-	repository->host = copy_substring(host_start, host_end);
+	repository.user = strndup(url->path, slash - url->path);
+	if (repository.user == NULL)
+		err(1, NULL);
 
-	user_start = host_end + 1;
-	user_end = strchr(user_start, '/');
-	if (user_end == NULL) {
-		free(repository->host);
-		repository->host = NULL;
-		return;
-	}
-	repository->user = copy_substring(user_start, user_end);
+	name_start = slash + 1;
+	suffix = find_git_suffix(name_start);
+	if (suffix != NULL)
+		repository.name = strndup(name_start, suffix - name_start);
+	else
+		repository.name = strdup(name_start);
+	if (repository.name == NULL)
+		err(1, NULL);
 
-	name_start = user_end + 1;
-	name_end = find_git_suffix(name_start);
-	if (name_end == NULL)
-		name_end = pattern + strlen(pattern);
-	repository->name = copy_substring(name_start, name_end);
+	return repository;
 }
 
 void
@@ -137,25 +120,9 @@ overload_repository_with_pattern(struct Repository *repository,
 }
 
 struct Repository
-extract_repository_from_pattern(const char *pattern)
-{
-	struct Repository repository = {NULL, NULL, NULL, UNDEFINED};
-
-	if (pattern == NULL)
-		return repository;
-
-	if (valid_git_ssh_pattern(pattern))
-		extract_repository_from_ssh_pattern(&repository, pattern);
-	else if (valid_git_https_pattern(pattern))
-		extract_repository_from_https_pattern(&repository, pattern);
-
-	return repository;
-}
-
-struct Repository
 extract_repository_from_cwd(const char *clone_path, const char *pattern)
 {
-	struct Repository repository = {NULL, NULL, NULL, SSH};
+	struct Repository repository = {NULL, NULL, NULL, SCHEME_SCP};
 	char cwd[PATH_MAX];
 	char *end, *start;
 	const char *suffix;
@@ -283,9 +250,9 @@ extract_https_url_from_repository(struct Repository repository)
 char *
 extract_url_from_repository(struct Repository repository)
 {
-	if (repository.protocol == SSH)
+	if (repository.scheme == SCHEME_SCP)
 		return extract_ssh_url_from_repository(repository);
-	else if (repository.protocol == HTTPS)
+	else if (repository.scheme == SCHEME_HTTPS)
 		return extract_https_url_from_repository(repository);
 	else
 		return NULL;
@@ -300,5 +267,5 @@ free_repository(struct Repository *repository)
 	repository->host = NULL;
 	repository->user = NULL;
 	repository->name = NULL;
-	repository->protocol = UNDEFINED;
+	repository->scheme = SCHEME_UNDEFINED;
 }

--- a/repository.c
+++ b/repository.c
@@ -45,7 +45,8 @@ extract_repository_from_url(const struct url *url)
 	if (url == NULL)
 		return repository;
 
-	if (url->scheme != SCHEME_SCP && url->scheme != SCHEME_HTTPS)
+	if (url->scheme != SCHEME_SCP && url->scheme != SCHEME_HTTPS &&
+	    url->scheme != SCHEME_SSH)
 		return repository;
 
 	repository.scheme = url->scheme;
@@ -59,6 +60,26 @@ extract_repository_from_url(const struct url *url)
 	if (url->path == NULL)
 		return repository;
 
+	if (url->scheme == SCHEME_SSH) {
+		/* ssh://user@host/repo -- user from URL, name from path */
+		if (url->user != NULL) {
+			repository.user = strdup(url->user);
+			if (repository.user == NULL)
+				err(1, NULL);
+		}
+		suffix = find_git_suffix(url->path);
+		if (suffix != NULL) {
+			repository.name = strndup(url->path,
+			    suffix - url->path);
+		} else {
+			repository.name = strdup(url->path);
+		}
+		if (repository.name == NULL)
+			err(1, NULL);
+		return repository;
+	}
+
+	/* SCP and HTTPS: path is user/repo */
 	slash = strchr(url->path, '/');
 	if (slash == NULL)
 		return repository;
@@ -248,12 +269,37 @@ extract_https_url_from_repository(struct Repository repository)
 }
 
 char *
+extract_ssh_url_string_from_repository(struct Repository repository)
+{
+	char *out;
+	int len;
+	size_t size;
+
+	len = snprintf(NULL, 0, "ssh://%s@%s/%s", repository.user,
+	    repository.host, repository.name);
+	if (len < 0 || (size_t)len > SIZE_MAX - 1)
+		return NULL;
+
+	size = (size_t)len + 1;
+	out = malloc(size);
+	if (out == NULL)
+		return NULL;
+
+	snprintf(out, size, "ssh://%s@%s/%s", repository.user,
+	    repository.host, repository.name);
+
+	return out;
+}
+
+char *
 extract_url_from_repository(struct Repository repository)
 {
 	if (repository.scheme == SCHEME_SCP)
 		return extract_ssh_url_from_repository(repository);
 	else if (repository.scheme == SCHEME_HTTPS)
 		return extract_https_url_from_repository(repository);
+	else if (repository.scheme == SCHEME_SSH)
+		return extract_ssh_url_string_from_repository(repository);
 	else
 		return NULL;
 }

--- a/repository.h
+++ b/repository.h
@@ -1,5 +1,5 @@
-#ifndef _REPOSITORY_H_
-#define _REPOSITORY_H_
+#ifndef _CLONE_REPOSITORY_H_
+#define _CLONE_REPOSITORY_H_
 
 #include <fnmatch.h>
 #include <limits.h>
@@ -8,20 +8,16 @@
 #include <string.h>
 #include <unistd.h>
 
-enum Protocol {
-	UNDEFINED,
-	SSH,
-	HTTPS,
-};
+#include "url.h"
 
 struct Repository {
-	char	*host;
-	char	*user;
-	char	*name;
-	enum Protocol protocol;
+	char		*host;
+	char		*user;
+	char		*name;
+	enum scheme	 scheme;
 };
 
-struct Repository	 extract_repository_from_pattern(const char *);
+struct Repository	 extract_repository_from_url(const struct url *);
 struct Repository	 extract_repository_from_cwd(const char *, const char *);
 void			 overload_repository_with_pattern(struct Repository *,
 			    const char *);
@@ -30,4 +26,4 @@ char			*extract_location_from_repository(const char *,
 char			*extract_url_from_repository(struct Repository);
 void			 free_repository(struct Repository *);
 
-#endif /* _REPOSITORY_H_ */
+#endif /* _CLONE_REPOSITORY_H_ */

--- a/repository.h
+++ b/repository.h
@@ -15,6 +15,7 @@ struct Repository {
 	char		*user;
 	char		*name;
 	char		*login_user;
+	char		*port;
 	enum scheme	 scheme;
 };
 

--- a/repository.h
+++ b/repository.h
@@ -14,6 +14,7 @@ struct Repository {
 	char		*host;
 	char		*user;
 	char		*name;
+	char		*login_user;
 	enum scheme	 scheme;
 };
 

--- a/tests/clone-inside-project-base-directory.sh
+++ b/tests/clone-inside-project-base-directory.sh
@@ -18,6 +18,15 @@ if testcase "clone full git+ssh git.sr.ht URLs inside clone's directory structur
     "$(clone "git@git.sr.ht:~user/project.git")"
 fi
 
+if testcase "clone full ssh:// URLs inside clone's directory structure"; then
+  assert_eq \
+    "git clone ssh://anonymous@got.gameoftrees.org/got $HOME/src/got.gameoftrees.org/anonymous/got" \
+    "$(clone "ssh://anonymous@got.gameoftrees.org/got.git")"
+  assert_eq \
+    "git clone ssh://anonymous@got.gameoftrees.org/got $HOME/src/got.gameoftrees.org/anonymous/got" \
+    "$(clone "ssh://anonymous@got.gameoftrees.org/got")"
+fi
+
 if testcase "clone full https github.com URLs inside clone's directory structure"; then
   assert_eq \
     "git clone https://github.com/user/project $HOME/src/github.com/user/project" \

--- a/tests/clone-inside-project-base-directory.sh
+++ b/tests/clone-inside-project-base-directory.sh
@@ -27,6 +27,18 @@ if testcase "clone full ssh:// URLs inside clone's directory structure"; then
     "$(clone "ssh://anonymous@got.gameoftrees.org/got")"
 fi
 
+if testcase "clone full ssh:// URLs with port inside clone's directory structure"; then
+  assert_eq \
+    "git clone ssh://anonymous@got.gameoftrees.org:2222/got $HOME/src/got.gameoftrees.org/anonymous/got" \
+    "$(clone "ssh://anonymous@got.gameoftrees.org:2222/got")"
+fi
+
+if testcase "clone full SCP URLs with non-git login user inside clone's directory structure"; then
+  assert_eq \
+    "git clone deploy@github.com:user/project $HOME/src/github.com/user/project" \
+    "$(clone "deploy@github.com:user/project")"
+fi
+
 if testcase "clone full https github.com URLs inside clone's directory structure"; then
   assert_eq \
     "git clone https://github.com/user/project $HOME/src/github.com/user/project" \
@@ -34,6 +46,12 @@ if testcase "clone full https github.com URLs inside clone's directory structure
   assert_eq \
     "git clone https://github.com/user/project $HOME/src/github.com/user/project" \
     "$(clone "https://github.com/user/project.git")"
+fi
+
+if testcase "clone full https:// URLs with port inside clone's directory structure"; then
+  assert_eq \
+    "git clone https://github.com:8443/user/project $HOME/src/github.com/user/project" \
+    "$(clone "https://github.com:8443/user/project")"
 fi
 
 if testcase "clone user/repository_name patterns inside clone's directory structure"; then

--- a/tests/clone-outside-project-base-directory.sh
+++ b/tests/clone-outside-project-base-directory.sh
@@ -37,4 +37,13 @@ if testcase "clone full https:// any other URLs outside clone's directory struct
     "$(clone "https://example.com/user/project.git")"
 fi
 
+if testcase "clone full ssh:// URLs outside clone's directory structure"; then
+  assert_eq \
+    "git clone ssh://anonymous@got.gameoftrees.org/got $HOME/src/got.gameoftrees.org/anonymous/got" \
+    "$(clone "ssh://anonymous@got.gameoftrees.org/got.git")"
+  assert_eq \
+    "git clone ssh://anonymous@got.gameoftrees.org/got $HOME/src/got.gameoftrees.org/anonymous/got" \
+    "$(clone "ssh://anonymous@got.gameoftrees.org/got")"
+fi
+
 rmdir "$tmpdir"

--- a/tests/clone-outside-project-base-directory.sh
+++ b/tests/clone-outside-project-base-directory.sh
@@ -55,4 +55,16 @@ if testcase "clone full ssh:// URLs outside clone's directory structure"; then
     "$(clone "ssh://anonymous@got.gameoftrees.org/got")"
 fi
 
+if testcase "clone ssh:// URLs with port outside clone's directory structure"; then
+  assert_eq \
+    "git clone ssh://anonymous@got.gameoftrees.org:2222/got $HOME/src/got.gameoftrees.org/anonymous/got" \
+    "$(clone "ssh://anonymous@got.gameoftrees.org:2222/got")"
+fi
+
+if testcase "clone https:// URLs with port outside clone's directory structure"; then
+  assert_eq \
+    "git clone https://github.com:8443/user/project $HOME/src/github.com/user/project" \
+    "$(clone "https://github.com:8443/user/project")"
+fi
+
 rmdir "$tmpdir"

--- a/tests/clone-outside-project-base-directory.sh
+++ b/tests/clone-outside-project-base-directory.sh
@@ -37,6 +37,15 @@ if testcase "clone full https:// any other URLs outside clone's directory struct
     "$(clone "https://example.com/user/project.git")"
 fi
 
+if testcase "clone full SCP URLs with non-git login user outside clone's directory structure"; then
+  assert_eq \
+    "git clone deploy@github.com:user/project $HOME/src/github.com/user/project" \
+    "$(clone "deploy@github.com:user/project")"
+  assert_eq \
+    "git clone deploy@github.com:user/project $HOME/src/github.com/user/project" \
+    "$(clone "deploy@github.com:user/project.git")"
+fi
+
 if testcase "clone full ssh:// URLs outside clone's directory structure"; then
   assert_eq \
     "git clone ssh://anonymous@got.gameoftrees.org/got $HOME/src/got.gameoftrees.org/anonymous/got" \

--- a/tests/clone-outside-project-base-directory.sh
+++ b/tests/clone-outside-project-base-directory.sh
@@ -59,12 +59,18 @@ if testcase "clone ssh:// URLs with port outside clone's directory structure"; t
   assert_eq \
     "git clone ssh://anonymous@got.gameoftrees.org:2222/got $HOME/src/got.gameoftrees.org/anonymous/got" \
     "$(clone "ssh://anonymous@got.gameoftrees.org:2222/got")"
+  assert_eq \
+    "git clone ssh://anonymous@got.gameoftrees.org:2222/got $HOME/src/got.gameoftrees.org/anonymous/got" \
+    "$(clone "ssh://anonymous@got.gameoftrees.org:2222/got.git")"
 fi
 
 if testcase "clone https:// URLs with port outside clone's directory structure"; then
   assert_eq \
     "git clone https://github.com:8443/user/project $HOME/src/github.com/user/project" \
     "$(clone "https://github.com:8443/user/project")"
+  assert_eq \
+    "git clone https://github.com:8443/user/project $HOME/src/github.com/user/project" \
+    "$(clone "https://github.com:8443/user/project.git")"
 fi
 
 rmdir "$tmpdir"

--- a/tests/clone-rejects-bad-patterns.sh
+++ b/tests/clone-rejects-bad-patterns.sh
@@ -11,6 +11,9 @@ if testcase "clone rejects bad patterns - http://"; then
   assert_eq \
     "clone: could not extract repository: http://github.com/user/project" \
     "$(clone "http://github.com/user/project")"
+  assert_eq \
+    "clone: could not extract repository: http://github.com:8080/user/project" \
+    "$(clone "http://github.com:8080/user/project")"
 fi
 
 if testcase "clone rejects bad patterns - ftp://"; then
@@ -56,6 +59,15 @@ if testcase "clone rejects path traversal in repository name"; then
   assert_eq \
     "clone: could not extract repository: ssh://anonymous@got.gameoftrees.org/../got" \
     "$(clone "ssh://anonymous@got.gameoftrees.org/../got")"
+fi
+
+if testcase "clone rejects path traversal in port"; then
+  assert_eq \
+    "clone: could not extract repository: ssh://user@host:../22/got" \
+    "$(clone "ssh://user@host:../22/got")"
+  assert_eq \
+    "clone: could not extract repository: https://host:../user/repo" \
+    "$(clone "https://host:../user/repo")"
 fi
 
 if testcase "clone rejects bad patterns - ssh:// deep path"; then

--- a/tests/clone-rejects-bad-patterns.sh
+++ b/tests/clone-rejects-bad-patterns.sh
@@ -7,15 +7,6 @@ if testcase "clone rejects bad patterns - git://"; then
     "$(clone "git://github.com/user/project.git")"
 fi
 
-if testcase "clone rejects bad patterns - ssh://"; then
-  assert_eq \
-    "clone: could not extract repository: ssh://git@github.com:user/project" \
-    "$(clone "ssh://git@github.com:user/project")"
-  assert_eq \
-    "clone: could not extract repository: ssh://git@github.com:user/project.git" \
-    "$(clone "ssh://git@github.com:user/project.git")"
-fi
-
 if testcase "clone rejects path traversal in hostname"; then
   assert_eq \
     "clone: could not extract repository: git@../../etc:user/repo" \
@@ -23,6 +14,9 @@ if testcase "clone rejects path traversal in hostname"; then
   assert_eq \
     "clone: could not extract repository: git@foo/../bar:user/repo" \
     "$(clone "git@foo/../bar:user/repo")"
+  assert_eq \
+    "clone: could not extract repository: ssh://anonymous@../../etc/repo" \
+    "$(clone "ssh://anonymous@../../etc/repo")"
 fi
 
 if testcase "clone rejects path traversal in user"; then
@@ -32,6 +26,9 @@ if testcase "clone rejects path traversal in user"; then
   assert_eq \
     "clone: could not extract repository: https://github.com/../user/repo" \
     "$(clone "https://github.com/../user/repo")"
+  assert_eq \
+    "clone: could not extract repository: ssh://..@got.gameoftrees.org/got" \
+    "$(clone "ssh://..@got.gameoftrees.org/got")"
 fi
 
 if testcase "clone rejects path traversal in repository name"; then
@@ -41,4 +38,13 @@ if testcase "clone rejects path traversal in repository name"; then
   assert_eq \
     "clone: could not extract repository: git@github.com:user/repo/../other" \
     "$(clone "git@github.com:user/repo/../other")"
+  assert_eq \
+    "clone: could not extract repository: ssh://anonymous@got.gameoftrees.org/../got" \
+    "$(clone "ssh://anonymous@got.gameoftrees.org/../got")"
+fi
+
+if testcase "clone rejects bad patterns - ssh:// deep path"; then
+  assert_eq \
+    "clone: could not extract repository: ssh://anonymous@got.gameoftrees.org/a/b/got" \
+    "$(clone "ssh://anonymous@got.gameoftrees.org/a/b/got")"
 fi

--- a/tests/clone-rejects-bad-patterns.sh
+++ b/tests/clone-rejects-bad-patterns.sh
@@ -1,27 +1,27 @@
 if testcase "clone rejects bad patterns - git://"; then
   assert_eq \
-    "clone: could not extract repository: git://github.com/user/project" \
+    "clone: unsupported protocol: git://github.com/user/project" \
     "$(clone "git://github.com/user/project")"
   assert_eq \
-    "clone: could not extract repository: git://github.com/user/project.git" \
+    "clone: unsupported protocol: git://github.com/user/project.git" \
     "$(clone "git://github.com/user/project.git")"
 fi
 
 if testcase "clone rejects bad patterns - http://"; then
   assert_eq \
-    "clone: could not extract repository: http://github.com/user/project" \
+    "clone: unsupported protocol: http://github.com/user/project" \
     "$(clone "http://github.com/user/project")"
   assert_eq \
-    "clone: could not extract repository: http://github.com:8080/user/project" \
+    "clone: unsupported protocol: http://github.com:8080/user/project" \
     "$(clone "http://github.com:8080/user/project")"
 fi
 
 if testcase "clone rejects bad patterns - ftp://"; then
   assert_eq \
-    "clone: could not extract repository: ftp://github.com/user/project" \
+    "clone: unsupported protocol: ftp://github.com/user/project" \
     "$(clone "ftp://github.com/user/project")"
   assert_eq \
-    "clone: could not extract repository: ftps://github.com/user/project" \
+    "clone: unsupported protocol: ftps://github.com/user/project" \
     "$(clone "ftps://github.com/user/project")"
 fi
 

--- a/tests/clone-rejects-bad-patterns.sh
+++ b/tests/clone-rejects-bad-patterns.sh
@@ -7,6 +7,21 @@ if testcase "clone rejects bad patterns - git://"; then
     "$(clone "git://github.com/user/project.git")"
 fi
 
+if testcase "clone rejects bad patterns - http://"; then
+  assert_eq \
+    "clone: could not extract repository: http://github.com/user/project" \
+    "$(clone "http://github.com/user/project")"
+fi
+
+if testcase "clone rejects bad patterns - ftp://"; then
+  assert_eq \
+    "clone: could not extract repository: ftp://github.com/user/project" \
+    "$(clone "ftp://github.com/user/project")"
+  assert_eq \
+    "clone: could not extract repository: ftps://github.com/user/project" \
+    "$(clone "ftps://github.com/user/project")"
+fi
+
 if testcase "clone rejects path traversal in hostname"; then
   assert_eq \
     "clone: could not extract repository: git@../../etc:user/repo" \

--- a/url.c
+++ b/url.c
@@ -32,7 +32,7 @@ parse_scp(const char *pattern, struct url *url)
 static int
 parse_standard_url(const char *pattern, struct url *url, enum scheme scheme)
 {
-	const char *at, *host_end, *host_start, *proto;
+	const char *at, *colon, *host_end, *host_start, *proto;
 
 	proto = strstr(pattern, "://");
 	if (proto == NULL)
@@ -54,7 +54,16 @@ parse_standard_url(const char *pattern, struct url *url, enum scheme scheme)
 		host_start = at + 1;
 	}
 
-	url->host = strndup(host_start, host_end - host_start);
+	/* extract port from host:port if present */
+	colon = memchr(host_start, ':', host_end - host_start);
+	if (colon != NULL) {
+		url->port = strndup(colon + 1, host_end - (colon + 1));
+		if (url->port == NULL)
+			err(1, NULL);
+		url->host = strndup(host_start, colon - host_start);
+	} else {
+		url->host = strndup(host_start, host_end - host_start);
+	}
 	if (url->host == NULL)
 		err(1, NULL);
 

--- a/url.c
+++ b/url.c
@@ -32,7 +32,7 @@ parse_scp(const char *pattern, struct url *url)
 static int
 parse_standard_url(const char *pattern, struct url *url, enum scheme scheme)
 {
-	const char *host_end, *host_start, *proto;
+	const char *at, *host_end, *host_start, *proto;
 
 	proto = strstr(pattern, "://");
 	if (proto == NULL)
@@ -44,6 +44,15 @@ parse_standard_url(const char *pattern, struct url *url, enum scheme scheme)
 		return -1;
 
 	url->scheme = scheme;
+
+	/* extract user from user@host if present */
+	at = memchr(host_start, '@', host_end - host_start);
+	if (at != NULL) {
+		url->user = strndup(host_start, at - host_start);
+		if (url->user == NULL)
+			err(1, NULL);
+		host_start = at + 1;
+	}
 
 	url->host = strndup(host_start, host_end - host_start);
 	if (url->host == NULL)

--- a/url.c
+++ b/url.c
@@ -1,0 +1,93 @@
+#include "clone.h"
+#include "url.h"
+
+static int
+parse_scp(const char *pattern, struct url *url)
+{
+	const char *at, *colon;
+
+	at = strchr(pattern, '@');
+	colon = strchr(pattern, ':');
+
+	if (at == NULL || colon == NULL || at >= colon)
+		return -1;
+
+	url->scheme = SCHEME_SCP;
+
+	url->user = strndup(pattern, at - pattern);
+	if (url->user == NULL)
+		err(1, NULL);
+
+	url->host = strndup(at + 1, colon - (at + 1));
+	if (url->host == NULL)
+		err(1, NULL);
+
+	url->path = strdup(colon + 1);
+	if (url->path == NULL)
+		err(1, NULL);
+
+	return 0;
+}
+
+static int
+parse_standard_url(const char *pattern, struct url *url, enum scheme scheme)
+{
+	const char *host_end, *host_start, *proto;
+
+	proto = strstr(pattern, "://");
+	if (proto == NULL)
+		return -1;
+
+	host_start = proto + 3;
+	host_end = strchr(host_start, '/');
+	if (host_end == NULL)
+		return -1;
+
+	url->scheme = scheme;
+
+	url->host = strndup(host_start, host_end - host_start);
+	if (url->host == NULL)
+		err(1, NULL);
+
+	url->path = strdup(host_end + 1);
+	if (url->path == NULL)
+		err(1, NULL);
+
+	return 0;
+}
+
+int
+parse_url(const char *pattern, struct url *url)
+{
+	if (pattern == NULL || url == NULL)
+		return -1;
+
+	memset(url, 0, sizeof(*url));
+	url->scheme = SCHEME_UNDEFINED;
+
+	if (strncmp(pattern, "https://", 8) == 0)
+		return parse_standard_url(pattern, url, SCHEME_HTTPS);
+	if (strncmp(pattern, "git://", 6) == 0)
+		return parse_standard_url(pattern, url, SCHEME_GIT);
+	if (strncmp(pattern, "ssh://", 6) == 0)
+		return parse_standard_url(pattern, url, SCHEME_SSH);
+
+	if (fnmatch("git@*:*/*", pattern, 0) == 0)
+		return parse_scp(pattern, url);
+
+	return -1;
+}
+
+void
+free_url(struct url *url)
+{
+	free(url->user);
+	free(url->host);
+	free(url->port);
+	free(url->path);
+	url->user = NULL;
+	url->host = NULL;
+	url->port = NULL;
+	url->path = NULL;
+	url->scheme = SCHEME_UNDEFINED;
+}

--- a/url.c
+++ b/url.c
@@ -81,7 +81,7 @@ parse_url(const char *pattern, struct url *url)
 	if (strncmp(pattern, "ssh://", 6) == 0)
 		return parse_standard_url(pattern, url, SCHEME_SSH);
 
-	if (fnmatch("git@*:*/*", pattern, 0) == 0)
+	if (fnmatch("*@*:*/*", pattern, 0) == 0)
 		return parse_scp(pattern, url);
 
 	return -1;

--- a/url.c
+++ b/url.c
@@ -90,6 +90,13 @@ parse_url(const char *pattern, struct url *url)
 	if (strncmp(pattern, "ssh://", 6) == 0)
 		return parse_standard_url(pattern, url, SCHEME_SSH);
 
+	if (strncmp(pattern, "http://", 7) == 0)
+		return parse_standard_url(pattern, url, SCHEME_HTTP);
+	if (strncmp(pattern, "ftps://", 7) == 0)
+		return parse_standard_url(pattern, url, SCHEME_FTP);
+	if (strncmp(pattern, "ftp://", 6) == 0)
+		return parse_standard_url(pattern, url, SCHEME_FTP);
+
 	if (fnmatch("*@*:*/*", pattern, 0) == 0)
 		return parse_scp(pattern, url);
 

--- a/url.h
+++ b/url.h
@@ -1,0 +1,23 @@
+#ifndef _CLONE_URL_H_
+#define _CLONE_URL_H_
+
+enum scheme {
+	SCHEME_UNDEFINED,
+	SCHEME_SCP,	/* [user@]host:path */
+	SCHEME_SSH,	/* ssh://[user@]host/path */
+	SCHEME_HTTPS,	/* https://host/path */
+	SCHEME_GIT,	/* git://host/path */
+};
+
+struct url {
+	enum scheme	 scheme;
+	char		*user;
+	char		*host;
+	char		*port;
+	char		*path;
+};
+
+int	 parse_url(const char *, struct url *);
+void	 free_url(struct url *);
+
+#endif /* _CLONE_URL_H_ */

--- a/url.h
+++ b/url.h
@@ -3,9 +3,13 @@
 
 enum scheme {
 	SCHEME_UNDEFINED,
+
+	/* Supported */
 	SCHEME_SCP,	/* [user@]host:path */
 	SCHEME_SSH,	/* ssh://[user@]host/path */
 	SCHEME_HTTPS,	/* https://host/path */
+
+	/* Unsupported: no authentication, transmitted in cleartext */
 	SCHEME_GIT,	/* git://host/path */
 	SCHEME_HTTP,	/* http://host/path */
 	SCHEME_FTP,	/* ftp[s]://host/path */

--- a/url.h
+++ b/url.h
@@ -7,6 +7,8 @@ enum scheme {
 	SCHEME_SSH,	/* ssh://[user@]host/path */
 	SCHEME_HTTPS,	/* https://host/path */
 	SCHEME_GIT,	/* git://host/path */
+	SCHEME_HTTP,	/* http://host/path */
+	SCHEME_FTP,	/* ftp[s]://host/path */
 };
 
 struct url {


### PR DESCRIPTION
Supersedes #6.

Add support for all URL types documented in the GIT URLS section
of git-pull(1), except those explicitly rejected (git://, http://,
ftp[s]://).

Supported:

- ssh://[user@]host[:port]/repository[.git]
- https://host[:port]/user/repository[.git]
- [user@]host:user/repository[.git] (SCP-like, any login user)
- user/repository and repository (shorthand, inside clone structure)

Rejected with "unsupported protocol":

- git:// (insecure, no authentication)
- http:// (insecure)
- ftp[s]:// (deprecated)

The main structural change is extracting URL parsing into url.{c,h}
with a struct url and enum scheme. This replaces enum Protocol and
the scattered fnmatch-based pattern validation with a single
parse_url() entry point.

Other changes:

- SCP-like URLs accept any SSH login user, not just git@. The
  login user is preserved in the clone URL for full patterns and
  defaults to git for shorthand patterns from the directory tree.
- Port numbers in ssh:// and https:// URLs are stripped from the
  directory path but preserved in the clone URL.
- Port and host fields are validated against path traversal.
- Error messages distinguish "unsupported protocol" from "could
  not extract repository".