### PR TITLE
Harden input validation and path matching

### DIFF
--- a/clone.c
+++ b/clone.c
@@ -57,7 +57,7 @@ char *
 get_clone_path(void)
 {
 	static char *cached_path = NULL;
-	char *expanded, *result;
+	char *expanded, *resolved, *result;
 	size_t len;
 
 	if (cached_path != NULL) {
@@ -75,6 +75,13 @@ get_clone_path(void)
 	len = strlen(expanded);
 	if (len > 0 && expanded[len - 1] == '/')
 		expanded[len - 1] = '\0';
+
+	/* resolve symlinks so getcwd() comparisons work */
+	resolved = realpath(expanded, NULL);
+	if (resolved != NULL) {
+		free(expanded);
+		expanded = resolved;
+	}
 
 	cached_path = expanded;
 	result = strdup(cached_path);

--- a/repository.c
+++ b/repository.c
@@ -160,15 +160,18 @@ extract_repository_from_cwd(const char *clone_path, const char *pattern)
 	char cwd[PATH_MAX];
 	char *end, *start;
 	const char *suffix;
+	size_t len;
 
 	if (getcwd(cwd, sizeof(cwd)) == NULL)
 		return repository;
 
-	start = strstr(cwd, clone_path);
-	if (start == NULL)
+	len = strlen(clone_path);
+	if (strncmp(cwd, clone_path, len) != 0)
+		return repository;
+	if (cwd[len] != '/' && cwd[len] != '\0')
 		return repository;
 
-	start += strlen(clone_path);
+	start = cwd + len;
 	if (*start == '/')
 		start++;
 	end = strchr(start, '/');
@@ -179,6 +182,7 @@ extract_repository_from_cwd(const char *clone_path, const char *pattern)
 		repository.host = strdup(start);
 		if (repository.host == NULL)
 			err(1, NULL);
+		start += strlen(start);
 	}
 
 	end = strchr(start, '/');
@@ -189,7 +193,7 @@ extract_repository_from_cwd(const char *clone_path, const char *pattern)
 		repository.user = strdup(start);
 		if (repository.user == NULL)
 			err(1, NULL);
-		start = start + strlen(start);
+		start += strlen(start);
 	}
 
 	end = strchr(start, '/');


### PR DESCRIPTION
extract_repository_from_cwd() used strstr() to locate the clone path
inside the working directory. This matched anywhere in the path rather
than requiring a prefix match, inconsistent with the strncmp() guard
in cwd_is_inside_clone_path(). The same function also failed to
advance its parse cursor past the host component when no slash
followed, duplicating the hostname as the user field.

All fnmatch() calls used flags=0, letting * match /. This made URL
validation patterns more permissive than intended -- git@host/evil:user/repo
would pass the SSH pattern check. FNM_PATHNAME restricts * to a single
path segment. Three-segment git:// variants are added to the unsupported
patterns list to preserve rejection coverage under the new flag.

The clone path is now resolved with realpath() so symlinked home
directories don't cause getcwd() comparisons to silently fail.