### PR TITLE
Remove unnecessary cleanup before err()/errx()

### DIFF
--- a/clone.c
+++ b/clone.c
@@ -183,22 +183,14 @@ main(int argc, char *argv[])
 		repository = extract_repository_from_cwd(clone_path, pattern);
 	}
 
-	if (invalid_repository(repository)) {
-		free(clone_path);
-		free_repository(&repository);
+	if (invalid_repository(repository))
 		errx(1, "could not extract repository: %s", pattern);
-	}
 
 	location = extract_location_from_repository(clone_path, repository);
 	clone_url = extract_url_from_repository(repository);
 
-	if (location == NULL || clone_url == NULL) {
-		free(clone_path);
-		free(location);
-		free(clone_url);
-		free_repository(&repository);
+	if (location == NULL || clone_url == NULL)
 		err(1, NULL);
-	}
 
 	if (nflag) {
 		fprintf(stdout, "%s %s %s\n", "git clone", clone_url, location);


### PR DESCRIPTION
The OS reclaims all process memory on exit. Freeing before
err()/errx() is unnecessary for a short-lived CLI utility and
adds complexity to every error path. This was previously removed
in fb92bf1 but re-added in 053aad8 to appease valgrind -- the
trade-off isn't worth it given the inconsistency it creates.
Cleanup is kept only on the normal nflag return path.