### PR TITLE
Use tmpdir for inside-project-base-directory tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,18 +22,10 @@ jobs:
       uses: actions/checkout@v4
 
     - name: make
-      run: |
-        mkdir -p $HOME/src/github.com/user/clone
-        cp -R * $HOME/src/github.com/user/clone
-        cd $HOME/src/github.com/user/clone
-
-        CC=${{ matrix.compiler }} make
+      run: CC=${{ matrix.compiler }} make
 
     - name: make test
-      run: |
-        cd $HOME/src/github.com/user/clone
-
-        CC=${{ matrix.compiler }} make test
+      run: CC=${{ matrix.compiler }} make test
 
   macos:
     name: macos + ${{ matrix.compiler }}
@@ -48,18 +40,10 @@ jobs:
       uses: actions/checkout@v4
 
     - name: make
-      run: |
-        mkdir -p $HOME/src/github.com/user/clone
-        cp -R * $HOME/src/github.com/user/clone
-        cd $HOME/src/github.com/user/clone
-
-        CC=${{ matrix.compiler }} make
+      run: CC=${{ matrix.compiler }} make
 
     - name: make test
-      run: |
-        cd $HOME/src/github.com/user/clone
-
-        CC=${{ matrix.compiler }} make test
+      run: CC=${{ matrix.compiler }} make test
 
   openbsd:
     name: openbsd
@@ -76,9 +60,5 @@ jobs:
         prepare: |
           pkg_add git
         run: |
-          mkdir -p $HOME/src/github.com/user/clone
-          cp -R * $HOME/src/github.com/user/clone
-          cd $HOME/src/github.com/user/clone
-
           make
           make test

--- a/tests/clone-inside-project-base-directory.sh
+++ b/tests/clone-inside-project-base-directory.sh
@@ -1,87 +1,91 @@
-cd "$ROOT" || exit 1
+tmpdir=$(mktemp -d) || exit 1
+tmpdir=$(cd "$tmpdir" && pwd -P)
+mkdir -p "$tmpdir/src/github.com/user/clone"
+
+cd "$tmpdir/src/github.com/user/clone" || exit 1
 
 if testcase "clone full git+ssh github.com URLs inside clone's directory structure"; then
   assert_eq \
-    "git clone git@github.com:user/project $HOME/src/github.com/user/project" \
-    "$(clone "git@github.com:user/project")"
+    "git clone git@github.com:user/project $tmpdir/src/github.com/user/project" \
+    "$(HOME=$tmpdir clone "git@github.com:user/project")"
   assert_eq \
-    "git clone git@github.com:user/project $HOME/src/github.com/user/project" \
-    "$(clone "git@github.com:user/project.git")"
+    "git clone git@github.com:user/project $tmpdir/src/github.com/user/project" \
+    "$(HOME=$tmpdir clone "git@github.com:user/project.git")"
 fi
 
 if testcase "clone full git+ssh git.sr.ht URLs inside clone's directory structure"; then
   assert_eq \
-    "git clone git@git.sr.ht:~user/project $HOME/src/git.sr.ht/~user/project" \
-    "$(clone "git@git.sr.ht:~user/project")"
+    "git clone git@git.sr.ht:~user/project $tmpdir/src/git.sr.ht/~user/project" \
+    "$(HOME=$tmpdir clone "git@git.sr.ht:~user/project")"
   assert_eq \
-    "git clone git@git.sr.ht:~user/project $HOME/src/git.sr.ht/~user/project" \
-    "$(clone "git@git.sr.ht:~user/project.git")"
+    "git clone git@git.sr.ht:~user/project $tmpdir/src/git.sr.ht/~user/project" \
+    "$(HOME=$tmpdir clone "git@git.sr.ht:~user/project.git")"
 fi
 
 if testcase "clone full ssh:// URLs inside clone's directory structure"; then
   assert_eq \
-    "git clone ssh://anonymous@got.gameoftrees.org/got $HOME/src/got.gameoftrees.org/anonymous/got" \
-    "$(clone "ssh://anonymous@got.gameoftrees.org/got.git")"
+    "git clone ssh://anonymous@got.gameoftrees.org/got $tmpdir/src/got.gameoftrees.org/anonymous/got" \
+    "$(HOME=$tmpdir clone "ssh://anonymous@got.gameoftrees.org/got.git")"
   assert_eq \
-    "git clone ssh://anonymous@got.gameoftrees.org/got $HOME/src/got.gameoftrees.org/anonymous/got" \
-    "$(clone "ssh://anonymous@got.gameoftrees.org/got")"
+    "git clone ssh://anonymous@got.gameoftrees.org/got $tmpdir/src/got.gameoftrees.org/anonymous/got" \
+    "$(HOME=$tmpdir clone "ssh://anonymous@got.gameoftrees.org/got")"
 fi
 
 if testcase "clone full ssh:// URLs with port inside clone's directory structure"; then
   assert_eq \
-    "git clone ssh://anonymous@got.gameoftrees.org:2222/got $HOME/src/got.gameoftrees.org/anonymous/got" \
-    "$(clone "ssh://anonymous@got.gameoftrees.org:2222/got")"
+    "git clone ssh://anonymous@got.gameoftrees.org:2222/got $tmpdir/src/got.gameoftrees.org/anonymous/got" \
+    "$(HOME=$tmpdir clone "ssh://anonymous@got.gameoftrees.org:2222/got")"
 fi
 
 if testcase "clone full SCP URLs with non-git login user inside clone's directory structure"; then
   assert_eq \
-    "git clone deploy@github.com:user/project $HOME/src/github.com/user/project" \
-    "$(clone "deploy@github.com:user/project")"
+    "git clone deploy@github.com:user/project $tmpdir/src/github.com/user/project" \
+    "$(HOME=$tmpdir clone "deploy@github.com:user/project")"
 fi
 
 if testcase "clone full https github.com URLs inside clone's directory structure"; then
   assert_eq \
-    "git clone https://github.com/user/project $HOME/src/github.com/user/project" \
-    "$(clone "https://github.com/user/project")"
+    "git clone https://github.com/user/project $tmpdir/src/github.com/user/project" \
+    "$(HOME=$tmpdir clone "https://github.com/user/project")"
   assert_eq \
-    "git clone https://github.com/user/project $HOME/src/github.com/user/project" \
-    "$(clone "https://github.com/user/project.git")"
+    "git clone https://github.com/user/project $tmpdir/src/github.com/user/project" \
+    "$(HOME=$tmpdir clone "https://github.com/user/project.git")"
 fi
 
 if testcase "clone full https:// URLs with port inside clone's directory structure"; then
   assert_eq \
-    "git clone https://github.com:8443/user/project $HOME/src/github.com/user/project" \
-    "$(clone "https://github.com:8443/user/project")"
+    "git clone https://github.com:8443/user/project $tmpdir/src/github.com/user/project" \
+    "$(HOME=$tmpdir clone "https://github.com:8443/user/project")"
 fi
 
 if testcase "clone user/repository_name patterns inside clone's directory structure"; then
+  cd "$tmpdir/src/github.com/user/clone" || exit 1
+
   assert_eq \
-    "git clone git@github.com:another-user/project $HOME/src/github.com/another-user/project" \
-    "$(clone "another-user/project")"
+    "git clone git@github.com:another-user/project $tmpdir/src/github.com/another-user/project" \
+    "$(HOME=$tmpdir clone "another-user/project")"
   assert_eq \
-    "git clone git@github.com:another-user/project $HOME/src/github.com/another-user/project" \
-    "$(clone "another-user/project.git")"
+    "git clone git@github.com:another-user/project $tmpdir/src/github.com/another-user/project" \
+    "$(HOME=$tmpdir clone "another-user/project.git")"
 fi
 
 if testcase "clone repository_name patterns inside a user's clone directory structure"; then
-  prior=$(pwd)
-  user=$(basename "$(dirname "$ROOT")")
-  cd "$HOME/src/github.com/$user" || exit 1
+  cd "$tmpdir/src/github.com/user" || exit 1
 
   assert_eq \
-    "git clone git@github.com:$user/project $HOME/src/github.com/$user/project" \
-    "$(clone "project")"
+    "git clone git@github.com:user/project $tmpdir/src/github.com/user/project" \
+    "$(HOME=$tmpdir clone "project")"
   assert_eq \
-    "git clone git@github.com:$user/project $HOME/src/github.com/$user/project" \
-    "$(clone "project.git")"
-
-  cd "$prior" || exit 1
+    "git clone git@github.com:user/project $tmpdir/src/github.com/user/project" \
+    "$(HOME=$tmpdir clone "project.git")"
 fi
 
 if testcase "clone user/repository_name patterns inside a host of a clone directory structure"; then
-  cd "$HOME/src/github.com" || exit 1
+  cd "$tmpdir/src/github.com" || exit 1
 
   assert_eq \
-    "git clone git@github.com:another-user/project $HOME/src/github.com/another-user/project" \
-    "$(clone "another-user/project")"
+    "git clone git@github.com:another-user/project $tmpdir/src/github.com/another-user/project" \
+    "$(HOME=$tmpdir clone "another-user/project")"
 fi
+
+rm -rf "$tmpdir"


### PR DESCRIPTION
The tests assumed the checkout lived under ~/src, which fails when
running from a worktree or any other location outside the clone
path.

Build with a temporary CLONE_PATH instead so the tests are
self-contained.