### PR TITLE
Add CI summary job for branch protection

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,3 +62,14 @@ jobs:
         run: |
           make
           make test
+
+  ci:
+    name: CI
+    needs: [linux, macos, openbsd]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - run: |
+          [[ "${{ needs.linux.result }}" == "success" ]] || exit 1
+          [[ "${{ needs.macos.result }}" == "success" ]] || exit 1
+          [[ "${{ needs.openbsd.result }}" == "success" ]] || exit 1


### PR DESCRIPTION
Adds a summary `CI` job that depends on all three matrix jobs so
branch protection can require a single stable check name instead of
individual matrix entries.